### PR TITLE
Change postgres to mysql

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,10 @@ jobs:
     # here we set 3 docker images.
     docker:
       - image: cimg/ruby:2.7-node # this is our primary docker image, where step commands run.
-      - image: circleci/postgres
-        environment: # add POSTGRES environment variables.
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: test
+      - image: circleci/mysql:8.0.2
+        environment:
+          MYSQL_ROOT_PASSWORD: password
+          MYSQL_DATABASE: test
         name: db
       - image: selenium/standalone-chrome
         name: chrome
@@ -55,7 +54,7 @@ jobs:
       # up before we run operations on the database.
       - run:
           name: Wait for DB
-          command: dockerize -wait tcp://db:5432 -timeout 1m
+          command: dockerize -wait tcp://db:3306 -timeout 1m
       - run:
           name: Database setup
           command: bundle exec rails db:schema:load --trace

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ ruby '2.7.2'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.4'
-# Use postgresql as the database for Active Record
-gem 'pg', '>= 0.18', '< 2.0'
+# Use mysql as the database for Active Record
+gem 'mysql2'
 # Use Puma as the app server
 gem 'puma', '~> 4.1'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -209,6 +209,7 @@ GEM
     msgpack (1.4.2)
     multi_json (1.15.0)
     multipart-post (2.1.1)
+    mysql2 (0.5.3)
     nio4r (2.5.7)
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)
@@ -218,7 +219,6 @@ GEM
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
-    pg (1.2.3)
     popper_js (1.16.0)
     public_suffix (4.0.6)
     puma (4.3.7)
@@ -402,7 +402,7 @@ DEPENDENCIES
   kaminari
   listen (~> 3.2)
   mini_magick
-  pg (>= 0.18, < 2.0)
+  mysql2
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.4)
   rails-erd

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
-  validates :name, presence: true, uniqueness: true, length: { maximum: 20 }
+  validates :name, presence: true, uniqueness: { case_sensitive: true }, length: { maximum: 20 }
   validates :location_id, presence: true
   validates :address, presence: true
 

--- a/app/views/food_shares/_distance_matrix.html.erb
+++ b/app/views/food_shares/_distance_matrix.html.erb
@@ -1,4 +1,4 @@
-<% if current_user.id != @food_share.user_id %>
+<% if current_user.id != @food_share.user_id && @output_distance.present? %>
   <div class="bg-info">
     <%= "あなたの自宅から徒歩 #{@output_distance[:duration]}" %><br/>
     <%= "距離は#{@output_distance[:distance]}です。" %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,11 +1,10 @@
 default: &default
-  adapter: postgresql
+  adapter: mysql2
   encoding: utf8
-  min_messages: WARNING
+  port: 3306
+  username: root
+  password: password
   host: db
-  port: 5432
-  username: postgres
-  password: postgres
   pool: 5
   timeout: 5000
   stats_execution_limit: 10

--- a/db/migrate/20201223110710_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20201223110710_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -8,7 +8,10 @@ AddMissingUniqueIndices.class_eval do
   def self.up
     add_index ActsAsTaggableOn.tags_table, :name, unique: true
 
-    remove_index ActsAsTaggableOn.taggings_table, :tag_id if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+    if index_exists?(ActsAsTaggableOn.taggings_table, :tag_id)
+      remove_foreign_key :taggings, :tags
+      remove_index ActsAsTaggableOn.taggings_table, :tag_id
+    end
     remove_index ActsAsTaggableOn.taggings_table, name: 'taggings_taggable_context_idx'
     add_index ActsAsTaggableOn.taggings_table,
               [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,10 +12,7 @@
 
 ActiveRecord::Schema.define(version: 2021_02_11_071621) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
-  create_table "cities", force: :cascade do |t|
+  create_table "cities", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.integer "location_id"
     t.float "lon"
@@ -24,7 +21,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "favorites", force: :cascade do |t|
+  create_table "favorites", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "food_record_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -34,7 +31,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["user_id"], name: "index_favorites_on_user_id"
   end
 
-  create_table "food_records", force: :cascade do |t|
+  create_table "food_records", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "food_name"
     t.integer "healthy_score"
@@ -58,7 +55,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["user_id"], name: "index_food_records_on_user_id"
   end
 
-  create_table "food_shares", force: :cascade do |t|
+  create_table "food_shares", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "food_name"
     t.integer "limit_number"
     t.bigint "user_id", null: false
@@ -75,7 +72,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["user_id"], name: "index_food_shares_on_user_id"
   end
 
-  create_table "fr_comments", force: :cascade do |t|
+  create_table "fr_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "food_record_id", null: false
     t.text "content"
@@ -85,7 +82,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["user_id"], name: "index_fr_comments_on_user_id"
   end
 
-  create_table "fs_comments", force: :cascade do |t|
+  create_table "fs_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "food_share_id", null: false
     t.text "content"
@@ -95,7 +92,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["user_id"], name: "index_fs_comments_on_user_id"
   end
 
-  create_table "matchings", force: :cascade do |t|
+  create_table "matchings", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.bigint "food_share_id", null: false
     t.datetime "created_at", precision: 6, null: false
@@ -106,7 +103,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["user_id"], name: "index_matchings_on_user_id"
   end
 
-  create_table "relationships", force: :cascade do |t|
+  create_table "relationships", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "follow_id"
     t.datetime "created_at", precision: 6, null: false
@@ -116,7 +113,7 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["user_id"], name: "index_relationships_on_user_id"
   end
 
-  create_table "taggings", id: :serial, force: :cascade do |t|
+  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "tag_id"
     t.string "taggable_type"
     t.integer "taggable_id"
@@ -135,15 +132,15 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
   end
 
-  create_table "tags", id: :serial, force: :cascade do |t|
-    t.string "name"
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", collation: "utf8_bin"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "taggings_count", default: 0
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -174,5 +171,4 @@ ActiveRecord::Schema.define(version: 2021_02_11_071621) do
   add_foreign_key "matchings", "users"
   add_foreign_key "relationships", "users"
   add_foreign_key "relationships", "users", column: "follow_id"
-  add_foreign_key "taggings", "tags"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,15 @@
 version: '3'
 services:
   db:
-    image: postgres
-    ports:
-      - "5432:5432"
-    volumes:
-      - data:/var/lib/postgresql/data:cached
+    image: mysql:8.0.2
     environment:
-      POSTGRES_PASSWORD: postgres
+      MYSQL_ROOT_PASSWORD: password
+    ports:
+      - '3306:3306'
+    command: --default-authentication-plugin=mysql_native_password
+    volumes:
+      - data:/var/lib/mysql:cached
+
   redis:
     image: redis
     ports:

--- a/qs
+++ b/qs
@@ -38,8 +38,8 @@ create_project() {
   compose_build $app
   bundle_cmd install
 
-  echoing "Exec rails new with postgresql and webpack"
-  bundle_exec rails new . -f -d=postgresql $*
+  echoing "Exec rails new with mysql and webpack"
+  bundle_exec rails new . -f -d=mysql $*
 
   echoing "Update config/database.yml"
   mv database.yml config/database.yml
@@ -261,24 +261,24 @@ rake_reset_db() {
 db_console() {
     # from config/database.yml
     database="development"
-    username="postgres"
-    port="5432"
+    username="root"
+    port="3306"
 
-    run_db psql -h $db_container -p $port -U $username $database
+    run_db mysql -h $db_container -p $port -U $username $database
 }
 
 db_dump() {
     # from config/database.yml
     database="development"
-    username="postgres"
-    port="5432"
+    username="root"
+    port="3306"
 
     tm=$(date +\%Y\%m\%d-\%H\%M)
     dump_file=tmp/dbdump-${dbname}-${tm}.dump
 
     echoing "Dump database $dbname data to $dump_file"
 
-    run_db pg_dump -h $db_container -p $port -U $username --disable-triggers $database > $dump_file
+    run_db mysqldump -h $db_container -p $port -U $username --disable-triggers $database > $dump_file
     echo "done"
 }
 

--- a/spec/models/food_share_spec.rb
+++ b/spec/models/food_share_spec.rb
@@ -165,7 +165,7 @@ RSpec.describe FoodShare, type: :model do
 
       it 'is invalid with give_time-12時間' do
         food_share.give_time = Time.zone.now + 24 * 3600 + 1
-        food_share.limit_time = Time.zone.now + 12 * 3600 + 1
+        food_share.limit_time = Time.zone.now + 12 * 3600 + 10
         food_share.valid?
         expect(food_share.errors.messages[:limit_time]).to include("は、お裾分け時間より12時間以上前の日時を入力して下さい")
       end

--- a/spec/support/spec_support.rb
+++ b/spec/support/spec_support.rb
@@ -83,7 +83,7 @@ module SpecSupport
   def set_distance_response
     # モックサーバーからのレスポンスのjsonファイルを読み込み
     external_api_response = ActiveSupport::JSON.decode(File.read("spec/fixtures/distance_matrix/distance_matrix.json")).to_json
-    stub_request(:get, "https://maps.googleapis.com/maps/api/distancematrix/json?destinations=35.7090259,139.7319925&key=testkey&language=ja-JA&mode=walking&origins=35.7090259,139.7319925").to_return(
+    stub_request(:get, "https://maps.googleapis.com/maps/api/distancematrix/json?destinations=35.709,139.732&key=testkey&language=ja-JA&mode=walking&origins=35.7090259,139.7319925").to_return(
       body: external_api_response,
       status: 200
     )


### PR DESCRIPTION
# 概要
- AWSデプロイにあたり、postgresのサポートが弱い。そのため、MySQLに変更。(closes #87 )
- MySQLへの変更に伴い、対応が必要な箇所を修正。
  - tag as taggable on
  - model validation
  - RSpec